### PR TITLE
Demo hover effect overriding with `DisclosureGroupStyle`

### DIFF
--- a/HoverEffectWeirdness/ContentView.swift
+++ b/HoverEffectWeirdness/ContentView.swift
@@ -9,6 +9,48 @@ import SwiftUI
 import RealityKit
 import RealityKitContent
 
+extension View {
+    /// Modify a view when possible.
+    /// - Parameter transform: This is designed to contain an enclosing `if` statement,
+    /// like for instance `if #available`.
+    /// `ViewBuilder`s return `nil` when `if` conditions are `false`.
+    @ViewBuilder func or(
+      @ViewBuilder _ transform: (Self) -> (some View)?
+    ) -> some View {
+      if let transformed = transform(self) { transformed } else { self }
+    }
+}
+
+private struct BareBonesDisclosureGroupStyle: DisclosureGroupStyle {
+    @State private var parentHoverEffectEnabled = true
+
+    func makeBody(configuration: Configuration) -> some View {
+        Button { configuration.isExpanded.toggle() } label: {
+            HStack {
+                configuration.label
+                VStack {
+                    let text = if parentHoverEffectEnabled {
+                        ("Disable", "")
+                    } else {
+                        ("Enable", "n't")
+                    }
+                    Button("\(text.0) parent hover effect") {
+                        parentHoverEffectEnabled.toggle()
+                    }
+                    Text("The hover effect is\(text.1) present here.")
+                        .padding(.top)
+                }
+            }.or {
+                if !parentHoverEffectEnabled {
+                    $0.hoverEffect()
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        if configuration.isExpanded { configuration.content }
+    }
+}
+
 struct ContentView: View {
     var body: some View {
         ScrollView {
@@ -25,6 +67,7 @@ struct ContentView: View {
                     .contentShape(.hoverEffect, .rect)
                     .hoverEffect()
             }
+            .disclosureGroupStyle(BareBonesDisclosureGroupStyle())
         }
         .padding()
     }


### PR DESCRIPTION
This is the code that will let you check out what I'm talking about [on Bluesky](https://bsky.app/profile/jessymeow.bsky.social/post/3llkmbdpxd22h). 

You can't do much to modify the hover effects on a `DisclosureGroupStyle`—you can disable them, but that disables them for all children as well. 

You can't mutate or initialize [`DisclosureGroupStyleConfiguration`](https://developer.apple.com/documentation/swiftui/disclosuregroupstyle/configuration), which means you can't rely on sending a modified configuration  over to [`AutomaticDisclosureGroupStyle`](https://developer.apple.com/documentation/swiftui/disclosuregroupstyle)'s `makeBody` function.

Hopefully you can find a good workaround until Apple makes this more flexible!